### PR TITLE
--cpu host-model does not work on many platforms - use host instead

### DIFF
--- a/vftool.bash
+++ b/vftool.bash
@@ -387,7 +387,7 @@ sudo virt-install --connect=qemu:///system \
     --disk $image,format=qcow2 \
     --ram 7000 \
     --vcpus $vcpus \
-    --cpu host-model \
+    --cpu host \
     --hvm \
     --os-variant rhel6 \
     --vnc \
@@ -481,7 +481,7 @@ sudo virt-install --connect=qemu:///system \
     --disk $image,format=qcow2,bus=virtio \
     --ram 7000 \
     --vcpus 3 \
-    --cpu host-model \
+    --cpu host \
     --hvm \
     --os-type linux \
     --os-variant rhel7 \


### PR DESCRIPTION
virt-install --cpu host-model doesn't work on rhel7 - use host instead
